### PR TITLE
chore: Update documentation to use specific version of puppeteer

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Please refer to: [test-report-generation.yml > "Generate a report" step](https:/
 
 ```
   - name: "Install browser via puppeteer"
-    run: npx puppeteer browsers install chrome
+    run: npx puppeteer@23.1.1 browsers install chrome
 
   - name: "Generate Security Report"
     uses: PCStefan/github-security-report-action@v3


### PR DESCRIPTION
The 23.2.0 version makes the CI to fail with an error: "Could not find Chrome (ver. 127.0.6533.119). This can occur if either"